### PR TITLE
Enable Flask Auto-Instrumentation

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,13 +36,8 @@ def lists ():
 		#Display the all Tasks
 		todos_l = todos.find()
 		a1="active"
-		# mock API calls
-		if randrange(10) % 2:
-			response = requests.get('https://google.com')
-			response.close()
-		else:
-			response = requests.get('https://google.com')
-			response.close()
+		# mock API call
+		response = requests.get('https://google.com')
 
 		return render_template('index.html',a1=a1,todos=todos_l,t=title,h=heading), 500
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==3.0.0
 pymongo==3.12.1
 requests==2.26.0
-opentelemetry-distro==0.43b0
-opentelemetry-exporter-otlp==1.22.0
+opentelemetry-distro==0.48b0
+opentelemetry-exporter-otlp==1.27.0


### PR DESCRIPTION
This PR fixes Flask auto instrumentation that was broken because the Flask package was not being detected in hte environment:
- `opentelemetry-bootstrap` not installing flask instrumentation package
- upon manual installation, instrumentation not creating root spans for Flask API calls

I found the fix to be updating the otel packages to a more recent version. The flask package is now installed and invoked correctly by `opentelemetry-bootstrap` and ``opentelemetry-instrument` commands respectively.

<img width="1512" height="856" alt="image" src="https://github.com/user-attachments/assets/c3f02cb6-35a6-4fca-850d-05c7c83d9997" />
